### PR TITLE
Properly detect rmt-cli errors

### DIFF
--- a/check_rmt_repos
+++ b/check_rmt_repos
@@ -34,10 +34,14 @@ UNKNOWN = 3
 
 def get_enabled_rmt_repos():
     repo_info_cmd = ['rmt-cli', 'repos', 'list', '--csv']
-    proc = subprocess.Popen(repo_info_cmd, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(
+        repo_info_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
     avail_repo_data, errors = proc.communicate()
 
-    if errors:
+    if errors or proc.returncode != 0:
         print('Error executing "rmt-cli repos list"')
         sys.exit(CRITICAL)
 
@@ -114,9 +118,9 @@ if args.framework:
     framework_to_use = args.framework
 
 configured_repo_ids = []
-not_enabled = { 'ids': [], 'descriptions': [] }
+not_enabled = {'ids': [], 'descriptions': []}
 missing_repo_dirs = []
-extra_enabled_repos = { 'ids': [], 'descriptions': [] }
+extra_enabled_repos = {'ids': [], 'descriptions': []}
 extra_mirrored_repos = []
 with open(args.config_file_path) as json_file:
     config_repos = json.load(json_file)
@@ -136,10 +140,10 @@ with open(args.config_file_path) as json_file:
             # filter that out
             full_repo_path = '/var/lib/rmt/public/repo/' \
                 + repo_info.get('location').strip('/').split('repo')[-1]
-    
+
             if mirrored_repos.get(full_repo_path):
                 del mirrored_repos[full_repo_path]
-    
+
             if not os.path.exists(full_repo_path):
                 missing_repo_dirs.append(full_repo_path)
 
@@ -154,7 +158,7 @@ if not_enabled['ids']:
     print('\t%s' % ' '.join(not_enabled['ids']))
     for description in not_enabled['descriptions']:
         print('\t%s' % description)
-        
+
 if missing_repo_dirs:
     print('Following repo directories are missing:')
     for missing_dir in missing_repo_dirs:

--- a/monitoring-plugins-rmt-repos.spec
+++ b/monitoring-plugins-rmt-repos.spec
@@ -17,7 +17,7 @@
 
 
 Name:           monitoring-plugins-rmt-repos
-Version:        20190718
+Version:        20190724
 Release:        0
 Summary:        Verify enablement and presence of RMT repositories
 License:        GPL-2.0


### PR DESCRIPTION
Currently `errors` is always `None`, because `stderr` from the subprocess isn't piped. Also added exit code check.