### PR TITLE
Fix incorrect reporting of SLES11 as extra

### DIFF
--- a/check_rmt_repos
+++ b/check_rmt_repos
@@ -139,7 +139,7 @@ with open(args.config_file_path) as json_file:
             # SLES 11 repo relative paths start with /repo, we have to
             # filter that out
             full_repo_path = '/var/lib/rmt/public/repo/' \
-                + repo_info.get('location').strip('/').split('repo')[-1]
+                + repo_info.get('location').strip('/').split('repo/')[-1]
 
             if mirrored_repos.get(full_repo_path):
                 del mirrored_repos[full_repo_path]

--- a/monitoring-plugins-rmt-repos.spec
+++ b/monitoring-plugins-rmt-repos.spec
@@ -17,7 +17,7 @@
 
 
 Name:           monitoring-plugins-rmt-repos
-Version:        20190724
+Version:        20190725
 Release:        0
 Summary:        Verify enablement and presence of RMT repositories
 License:        GPL-2.0


### PR DESCRIPTION
An extra slash (`/var/lib/rmt/public/repo//$RCE/SLES11-Pool/sle-11-x86_64`) breaks removal of this repo from the hash in the next code fragment:

```
if mirrored_repos.get(full_repo_path):
    del mirrored_repos[full_repo_path]
```