### PR TITLE
Remove SLE 11 special handling

### DIFF
--- a/check_rmt_repos
+++ b/check_rmt_repos
@@ -168,10 +168,8 @@ for config_repo in config_repos:
         not_enabled['descriptions'].append(
             config_repo.get('description')
         )
-    # SLES 11 repo relative paths start with /repo, we have to
-    # filter that out
     full_repo_path = '/var/lib/rmt/public/repo/' \
-        + config_repo.get('location').strip('/').split('repo')[-1]
+        + config_repo.get('location').strip('/')
 
     if mirrored_repos.get(full_repo_path):
         del mirrored_repos[full_repo_path]


### PR DESCRIPTION
SLE 11 has been EOL since March 2022 and RMT does not support SLE 11 registration protocol anyway. Drop the special case for SLE 11 which allows us to support other repos that have "repo" in the path name somewhere else without having to implement special checks.