### PR TITLE
added loop on mirror status to replace systemd timer functionality

### DIFF
--- a/check_repo_signatures
+++ b/check_repo_signatures
@@ -101,4 +101,12 @@ class RepoSignatureChecker
   end
 end
 
+loop do
+  mirror_status = `systemctl is-active rmt-server-mirror.service`
+  if mirror_status.strip.downcase == "active"
+    sleep 300
+  else
+    break
+  end
+end
 RepoSignatureChecker.new.run


### PR DESCRIPTION
added a loop to prevent check_repo_signatures from running while a mirror was active;  when this specific situation occurs it results in RepoSignaturesUnmatched alerts in the prometheus monitoring deployment.   we are currently checking the state of the mirror prior to starting check_repo_sig.sh in the check_repo_sig.service, but this did not completely resolve this specific issue.  the modification in this PR is part of a larger strategy to 1) no longer use check_repo_signatures.timer to invoke check_repo_sig every 5 minutes but instead invoke this check from the mirror service after the mirror process starts, and 2) only  check the state of the repo signatures after a mirror completes.  If an active mirror should fail or be stopped prior to completion the check will be invoked and alert to any issue(s).